### PR TITLE
perf: optimize tcp statsd stat flushing (#1349)

### DIFF
--- a/include/envoy/stats/stats.h
+++ b/include/envoy/stats/stats.h
@@ -101,6 +101,12 @@ public:
   virtual ~Sink() {}
 
   /**
+   * This will be called before a sequence of flushCounter() and flushGauge() calls. Sinks can
+   * choose to optimize writing if desired with a paired endFlush() call.
+   */
+  virtual void beginFlush() PURE;
+
+  /**
    * Flush a counter delta.
    */
   virtual void flushCounter(const std::string& name, uint64_t delta) PURE;
@@ -109,6 +115,12 @@ public:
    * Flush a gauge value.
    */
   virtual void flushGauge(const std::string& name, uint64_t value) PURE;
+
+  /**
+   * This will be called after beginFlush(), some number of flushCounter(), and some number of
+   * flushGauge(). Sinks can use this to optimize writing if desired.
+   */
+  virtual void endFlush() PURE;
 
   /**
    * Flush a histogram value.

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -33,9 +33,8 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
         "//source/common/config:utility_lib",
-        "//source/common/network:address_lib",
-        "//source/common/network:utility_lib",
     ],
 )
 

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -76,6 +76,15 @@ public:
    * integration tests where a mock runtime is not needed.
    */
   static Runtime::LoaderPtr createRuntime(Instance& server, Server::Configuration::Initial& config);
+
+  /**
+   * Helper for flushing counters and gauges to sinks. This takes care of calling beginFlush(),
+   * latching of counters and flushing, flushing of gauges, and calling endFlush(), on each sink.
+   * @param sinks supplies the list of sinks.
+   * @param store supplies the store to flush.
+   */
+  static void flushCountersAndGaugesToSinks(const std::list<Stats::SinkPtr>& sinks,
+                                            Stats::Store& store);
 };
 
 /**

--- a/test/common/stats/statsd_test.cc
+++ b/test/common/stats/statsd_test.cc
@@ -14,12 +14,13 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace Envoy {
 using testing::InSequence;
+using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 using testing::_;
 
+namespace Envoy {
 namespace Stats {
 namespace Statsd {
 
@@ -51,15 +52,26 @@ public:
   Network::MockClientConnection* connection_{};
 };
 
-TEST_F(TcpStatsdSinkTest, All) {
+TEST_F(TcpStatsdSinkTest, EmptyFlush) {
   InSequence s;
 
+  sink_->beginFlush();
   expectCreateConnection();
-  EXPECT_CALL(*connection_, write(BufferStringEqual("envoy.test_counter:1|c\n")));
-  sink_->flushCounter("test_counter", 1);
+  EXPECT_CALL(*connection_, write(BufferStringEqual("")));
+  sink_->endFlush();
+}
 
-  EXPECT_CALL(*connection_, write(BufferStringEqual("envoy.test_gauge:2|g\n")));
+TEST_F(TcpStatsdSinkTest, BasicFlow) {
+  InSequence s;
+
+  sink_->beginFlush();
+  sink_->flushCounter("test_counter", 1);
   sink_->flushGauge("test_gauge", 2);
+
+  expectCreateConnection();
+  EXPECT_CALL(*connection_,
+              write(BufferStringEqual("envoy.test_counter:1|c\nenvoy.test_gauge:2|g\n")));
+  sink_->endFlush();
 
   // Test a disconnect. We should connect again.
   connection_->raiseEvents(Network::ConnectionEvent::RemoteClose);
@@ -75,26 +87,51 @@ TEST_F(TcpStatsdSinkTest, All) {
   tls_.shutdownThread();
 }
 
+TEST_F(TcpStatsdSinkTest, BufferReallocate) {
+  InSequence s;
+
+  sink_->beginFlush();
+  for (int i = 0; i < 2000; i++) {
+    sink_->flushCounter("test_counter", 1);
+  }
+
+  expectCreateConnection();
+  EXPECT_CALL(*connection_, write(_)).WillOnce(Invoke([](Buffer::Instance& buffer) -> void {
+    std::string compare;
+    for (int i = 0; i < 2000; i++) {
+      compare += "envoy.test_counter:1|c\n";
+    }
+    EXPECT_EQ(compare, TestUtility::bufferToString(buffer));
+  }));
+  sink_->endFlush();
+}
+
 TEST_F(TcpStatsdSinkTest, Overflow) {
   InSequence s;
 
   // Synthetically set buffer above high watermark. Make sure we don't write anything.
   cluster_manager_.thread_local_cluster_.cluster_.info_->stats().upstream_cx_tx_bytes_buffered_.set(
       1024 * 1024 * 17);
+  sink_->beginFlush();
   sink_->flushCounter("test_counter", 1);
+  sink_->endFlush();
 
   // Lower and make sure we write.
   cluster_manager_.thread_local_cluster_.cluster_.info_->stats().upstream_cx_tx_bytes_buffered_.set(
       1024 * 1024 * 15);
+  sink_->beginFlush();
+  sink_->flushCounter("test_counter", 1);
   expectCreateConnection();
   EXPECT_CALL(*connection_, write(BufferStringEqual("envoy.test_counter:1|c\n")));
-  sink_->flushCounter("test_counter", 1);
+  sink_->endFlush();
 
   // Raise and make sure we don't write and kill connection.
   cluster_manager_.thread_local_cluster_.cluster_.info_->stats().upstream_cx_tx_bytes_buffered_.set(
       1024 * 1024 * 17);
-  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush));
+  sink_->beginFlush();
   sink_->flushCounter("test_counter", 1);
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush));
+  sink_->endFlush();
 
   EXPECT_EQ(2UL, cluster_manager_.thread_local_cluster_.cluster_.info_->stats_store_
                      .counter("statsd.cx_overflow")

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -59,9 +59,10 @@ public:
   MockSink();
   ~MockSink();
 
-  MOCK_METHOD1(initialize, void(Upstream::ClusterManager& cluster_manager));
+  MOCK_METHOD0(beginFlush, void());
   MOCK_METHOD2(flushCounter, void(const std::string& name, uint64_t delta));
   MOCK_METHOD2(flushGauge, void(const std::string& name, uint64_t value));
+  MOCK_METHOD0(endFlush, void());
   MOCK_METHOD2(onHistogramComplete, void(const std::string& name, uint64_t value));
   MOCK_METHOD2(onTimespanComplete, void(const std::string& name, std::chrono::milliseconds ms));
 };

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -9,8 +9,28 @@
 
 #include "gtest/gtest.h"
 
+using testing::InSequence;
+using testing::StrictMock;
+
 namespace Envoy {
 namespace Server {
+
+TEST(ServerInstanceUtil, flushHelper) {
+  InSequence s;
+
+  Stats::IsolatedStoreImpl store;
+  store.counter("hello").inc();
+  store.gauge("world").set(5);
+  std::unique_ptr<Stats::MockSink> sink(new StrictMock<Stats::MockSink>());
+  EXPECT_CALL(*sink, beginFlush());
+  EXPECT_CALL(*sink, flushCounter("hello", 1));
+  EXPECT_CALL(*sink, flushGauge("world", 5));
+  EXPECT_CALL(*sink, endFlush());
+
+  std::list<Stats::SinkPtr> sinks;
+  sinks.emplace_back(std::move(sink));
+  InstanceUtil::flushCountersAndGaugesToSinks(sinks, store);
+}
 
 // Class creates minimally viable server instance for testing.
 class ServerInstanceImplTest : public testing::TestWithParam<Network::Address::IpVersion> {


### PR DESCRIPTION
With small flush intervals and a lot of stats, this code starts showing
up pretty heavily on perf traces.