### PR TITLE
Fix override keyword

### DIFF
--- a/source/server/config/http/extauth_config.h
+++ b/source/server/config/http/extauth_config.h
@@ -20,7 +20,7 @@ public:
   std::string name() override { return "extauth"; }
 
   HttpFilterFactoryCb createFilterFactory(const Json::Object& json_config,
-                                          const std::string& stats_prefix, FactoryContext& context);
+                                          const std::string& stats_prefix, FactoryContext& context) override;
 };
 
 } // namespace Configuration


### PR DESCRIPTION
This branch wouldn't compile if I didn't have the override keyword on this method.