### PR TITLE
Envoy % escaping

### DIFF
--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -300,7 +300,15 @@ std::vector<FormatterProviderPtr> SubstitutionFormatParser::parse(const std::str
         current_token = "";
       }
 
-<<<<<<< HEAD
+      // escape '%%'
+      if (format.length() > pos+1) {
+        if (format[pos+1] == '%') {
+          current_token += '%';
+          pos++;
+          continue;
+        }
+      }
+
       std::smatch m;
       const std::string search_space = format.substr(pos);
       if (!std::regex_search(search_space, m, command_w_args_regex)) {
@@ -308,21 +316,6 @@ std::vector<FormatterProviderPtr> SubstitutionFormatParser::parse(const std::str
             fmt::format("Incorrect configuration: {}. Couldn't find valid command at position {}",
                         format, pos));
       }
-=======
-    // escape '%%'
-    if (format.length() > pos+1) {
-      if (format[pos+1] == '%') {
-        current_token += '%';
-        pos++;
-        continue;
-      }
-    }
-
-    if (!current_token.empty()) {
-      formatters.emplace_back(FormatterProviderPtr{new PlainStringFormatter(current_token)});
-      current_token = "";
-    }
->>>>>>> c5c5d4c8a7... formatter: escape percent sign in response format
 
       const std::string match = m.str(0);
       const std::string token = match.substr(1, match.length() - 2);

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -300,6 +300,7 @@ std::vector<FormatterProviderPtr> SubstitutionFormatParser::parse(const std::str
         current_token = "";
       }
 
+<<<<<<< HEAD
       std::smatch m;
       const std::string search_space = format.substr(pos);
       if (!std::regex_search(search_space, m, command_w_args_regex)) {
@@ -307,6 +308,21 @@ std::vector<FormatterProviderPtr> SubstitutionFormatParser::parse(const std::str
             fmt::format("Incorrect configuration: {}. Couldn't find valid command at position {}",
                         format, pos));
       }
+=======
+    // escape '%%'
+    if (format.length() > pos+1) {
+      if (format[pos+1] == '%') {
+        current_token += '%';
+        pos++;
+        continue;
+      }
+    }
+
+    if (!current_token.empty()) {
+      formatters.emplace_back(FormatterProviderPtr{new PlainStringFormatter(current_token)});
+      current_token = "";
+    }
+>>>>>>> c5c5d4c8a7... formatter: escape percent sign in response format
 
       const std::string match = m.str(0);
       const std::string token = match.substr(1, match.length() - 2);

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -2405,8 +2405,7 @@ TEST(SubstitutionFormatterTest, ParserFailures) {
       "RESP(FIRST)%",
       "%REQ(valid)% %NOT_VALID%",
       "%REQ(FIRST?SECOND%",
-      "%%",
-      "%%HOSTNAME%PROTOCOL%",
+      "%HOSTNAME%PROTOCOL%",
       "%protocol%",
       "%REQ(TEST):%",
       "%REQ(TEST):3q4%",
@@ -2449,6 +2448,54 @@ TEST(SubstitutionFormatterTest, ParserSuccesses) {
   }
 }
 
+<<<<<<< HEAD
+=======
+TEST(SubstitutionFormatterTest, EmptyFormatParse) {
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/"}};
+  Http::TestResponseHeaderMapImpl response_headers;
+  Http::TestResponseTrailerMapImpl response_trailers;
+  StreamInfo::MockStreamInfo stream_info;
+  std::string body;
+
+  auto providers = SubstitutionFormatParser::parse("");
+
+  EXPECT_EQ(providers.size(), 1);
+  EXPECT_EQ("", providers[0]->format(request_headers, response_headers, response_trailers,
+                                     stream_info, body));
+}
+
+TEST(SubstitutionFormatterTest, EscapingFormatParse) {
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/"}};
+  Http::TestResponseHeaderMapImpl response_headers;
+  Http::TestResponseTrailerMapImpl response_trailers;
+  StreamInfo::MockStreamInfo stream_info;
+  std::string body;
+
+  auto providers = SubstitutionFormatParser::parse("%%");
+
+  EXPECT_EQ(providers.size(), 1);
+  EXPECT_EQ("%", providers[0]->format(request_headers, response_headers, response_trailers,
+                                     stream_info, body));
+}
+
+TEST(SubstitutionFormatterTest, FormatterExtension) {
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/"}};
+  Http::TestResponseHeaderMapImpl response_headers;
+  Http::TestResponseTrailerMapImpl response_trailers;
+  StreamInfo::MockStreamInfo stream_info;
+  std::string body;
+
+  std::vector<CommandParserPtr> commands;
+  commands.push_back(std::make_unique<TestCommandParser>());
+
+  auto providers = SubstitutionFormatParser::parse("foo %COMMAND_EXTENSION(x)%", commands);
+
+  EXPECT_EQ(providers.size(), 2);
+  EXPECT_EQ("TestFormatter", providers[1]->format(request_headers, response_headers,
+                                                  response_trailers, stream_info, body));
+}
+
+>>>>>>> c5c5d4c8a7... formatter: escape percent sign in response format
 } // namespace
 } // namespace Formatter
 } // namespace Envoy

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -2448,8 +2448,6 @@ TEST(SubstitutionFormatterTest, ParserSuccesses) {
   }
 }
 
-<<<<<<< HEAD
-=======
 TEST(SubstitutionFormatterTest, EmptyFormatParse) {
   Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/"}};
   Http::TestResponseHeaderMapImpl response_headers;
@@ -2495,7 +2493,6 @@ TEST(SubstitutionFormatterTest, FormatterExtension) {
                                                   response_trailers, stream_info, body));
 }
 
->>>>>>> c5c5d4c8a7... formatter: escape percent sign in response format
 } // namespace
 } // namespace Formatter
 } // namespace Envoy


### PR DESCRIPTION
This is the fix for Envoy % escaping.
I have passing Envoy unit tests off of this, and both Alice and I have tested and confirmed that this solves the HelloFresh needs.